### PR TITLE
EoI ST improvement and simplified ES logic for AoE

### DIFF
--- a/apl/default_apl.simc
+++ b/apl/default_apl.simc
@@ -99,7 +99,7 @@ actions.st+=/tip_the_scales,if=buff.dragonrage.up&(((!talent.font_of_magic|talen
 # Fire breath logic. Play around blazing shards if outside of DR. DS optimization: Only cast if current fight will last 8s+ or encounter ends in less than 30s
 actions.st+=/call_action_list,name=fb,if=(!talent.dragonrage|variable.next_dragonrage>variable.dr_prep_time_st|!talent.animosity)&(buff.blazing_shards.remains<variable.r1_cast_time|buff.dragonrage.up)&(!cooldown.eternity_surge.up|!talent.event_horizon|!buff.dragonrage.up)&(target.time_to_die>=8|fight_remains<30)
 # Throw Star on CD, Don't overcap with Arcane Vigor.
-actions.st+=/shattering_star,if=(buff.essence_burst.stack<buff.essence_burst.max_stack|!talent.arcane_vigor)&(!cooldown.fire_breath.up|!talent.event_horizon)&(!buff.iridescence_blue.up|essence<3&!buff.essence_burst.up|talent.event_horizon)
+actions.st+=/shattering_star,if=(buff.essence_burst.stack<buff.essence_burst.max_stack|!talent.arcane_vigor)&(!cooldown.fire_breath.up|!talent.event_horizon)&(!buff.iridescence_blue.up|talent.event_horizon)
 # Eternity Surge logic. Play around blazing shards if outside of DR. DS optimization: Only cast if current fight will last 8s+ or encounter ends in less than 30s
 actions.st+=/call_action_list,name=es,if=(!talent.dragonrage|variable.next_dragonrage>variable.dr_prep_time_st|!talent.animosity)&(buff.blazing_shards.remains<variable.r1_cast_time|buff.dragonrage.up)&(target.time_to_die>=8|fight_remains<30)
 # Wait for FB/ES to be ready if spending another GCD would result in the cast no longer fitting inside of DR

--- a/apl/default_apl.simc
+++ b/apl/default_apl.simc
@@ -71,7 +71,7 @@ actions.aoe+=/call_action_list,name=green,if=talent.ancient_flame&!buff.ancient_
 actions.aoe+=/azure_strike,target_if=max:target.health.pct
 
 # Eternity Surge, use rank most applicable to targets.
-actions.es=eternity_surge,empower_to=1,target_if=max:target.health.pct,if=active_enemies<=1+talent.eternitys_span|buff.dragonrage.remains<1.75*spell_haste&buff.dragonrage.remains>=1*spell_haste|buff.dragonrage.up&(active_enemies==5|!talent.eternitys_span&active_enemies>=6|talent.eternitys_span&active_enemies>=8)
+actions.es=eternity_surge,empower_to=1,target_if=max:target.health.pct,if=active_enemies<=1+talent.eternitys_span|buff.dragonrage.remains<1.75*spell_haste&buff.dragonrage.remains>=1*spell_haste|buff.dragonrage.up&(active_enemies==5&!talent.font_of_magic|active_enemies>(3+talent.font_of_magic)*(1+talent.eternitys_span))|active_enemies>=6&!talent.eternitys_span
 actions.es+=/eternity_surge,empower_to=2,target_if=max:target.health.pct,if=active_enemies<=2+2*talent.eternitys_span|buff.dragonrage.remains<2.5*spell_haste&buff.dragonrage.remains>=1.75*spell_haste
 actions.es+=/eternity_surge,empower_to=3,target_if=max:target.health.pct,if=active_enemies<=3+3*talent.eternitys_span|!talent.font_of_magic|buff.dragonrage.remains<=3.25*spell_haste&buff.dragonrage.remains>=2.5*spell_haste
 actions.es+=/eternity_surge,empower_to=4,target_if=max:target.health.pct
@@ -99,7 +99,7 @@ actions.st+=/tip_the_scales,if=buff.dragonrage.up&(((!talent.font_of_magic|talen
 # Fire breath logic. Play around blazing shards if outside of DR. DS optimization: Only cast if current fight will last 8s+ or encounter ends in less than 30s
 actions.st+=/call_action_list,name=fb,if=(!talent.dragonrage|variable.next_dragonrage>variable.dr_prep_time_st|!talent.animosity)&(buff.blazing_shards.remains<variable.r1_cast_time|buff.dragonrage.up)&(!cooldown.eternity_surge.up|!talent.event_horizon|!buff.dragonrage.up)&(target.time_to_die>=8|fight_remains<30)
 # Throw Star on CD, Don't overcap with Arcane Vigor.
-actions.st+=/shattering_star,if=(buff.essence_burst.stack<buff.essence_burst.max_stack|!talent.arcane_vigor)&(!cooldown.fire_breath.up|!talent.event_horizon)&(!cooldown.eternity_surge.up&!buff.iridescence_blue.up|essence<3&!buff.essence_burst.up|talent.event_horizon)
+actions.st+=/shattering_star,if=(buff.essence_burst.stack<buff.essence_burst.max_stack|!talent.arcane_vigor)&(!cooldown.fire_breath.up|!talent.event_horizon)&(!buff.iridescence_blue.up|essence<3&!buff.essence_burst.up|talent.event_horizon)
 # Eternity Surge logic. Play around blazing shards if outside of DR. DS optimization: Only cast if current fight will last 8s+ or encounter ends in less than 30s
 actions.st+=/call_action_list,name=es,if=(!talent.dragonrage|variable.next_dragonrage>variable.dr_prep_time_st|!talent.animosity)&(buff.blazing_shards.remains<variable.r1_cast_time|buff.dragonrage.up)&(target.time_to_die>=8|fight_remains<30)
 # Wait for FB/ES to be ready if spending another GCD would result in the cast no longer fitting inside of DR


### PR DESCRIPTION
# R1 ES logic cleanup
Made the logic more generic, which improved font performance and some minor gains at specific target count/talent setup
There is potentially some wiggle room for doing R2 instead of R1 for certain target count/talent setups, but the gain would most likely be very minor; so saving that testing for another time.

new logic is basically just uprank properly for the appropriate target count until it's above max target count, then R1. On 5T you R1 without font talented.
`buff.dragonrage.up&(active_enemies==5&!talent.font_of_magic|active_enemies>(3+talent.font_of_magic)*(1+talent.eternitys_span))`

3T
https://www.raidbots.com/simbot/report/nXFseJXkXJhcceoHpJordr

4T
https://www.raidbots.com/simbot/report/eHWaDKCkf6e133HBdwiAAU

5T - sending R1 unless font of magic is talented
https://www.raidbots.com/simbot/report/ciaYLPiCHvYdGxr3L4V314
5T - Max ranking (No span is already R1 naturally so excluding those here)
https://www.raidbots.com/simbot/report/grPRNLa7oJTT48MHUFXqZS

6T
https://www.raidbots.com/simbot/report/u9WZBdxXUBaTV4uZsa6xdG

7T
https://www.raidbots.com/simbot/report/8vHRHQiz3oLJxa7Kcdkg5a

8T
https://www.raidbots.com/simbot/report/fv7N78MtexiNp3dqrzM4Ty

9T
https://www.raidbots.com/simbot/report/2b5mbKRcZ5N7W7ZiT7xPSa

10T
https://www.raidbots.com/simbot/report/jX4S3VRTdb1H1boQwFkfRB

# Cutoffs for R1 ES outside of DR
Without Span talented, casting R1 ES outside of DR is a gain on 6T+ (technically a *very* minor gain on 5T+ without font but it's pretty much variance so just setting it to a general 6 for simplicity).
Cutoff with Span talented is 14 without font and 17 with font - not including in APL, gains are minor and who even sims that high target count anyways.
The base here is the new logic from above.

6T
https://www.raidbots.com/simbot/report/kKn8sBzRZj77yiULhVomAP

7T
https://www.raidbots.com/simbot/report/4rxuzN5fYGxVuF2AWyHuSE

8T
https://www.raidbots.com/simbot/report/5HT8mzwHAXVGmv5j688BrU

9T
https://www.raidbots.com/simbot/report/oZY7dPWBxckVGGbrv9Cu6f

10T
https://www.raidbots.com/simbot/report/diemYqcmcaXSPtbDKBes8Y

# Removed Essence Check for SS with EoI

Natty
https://www.raidbots.com/simbot/report/fbncomKHWSW1v8tZGdgGey

PI
https://www.raidbots.com/simbot/report/boMwsgENyQkqHqUEi1JBKh
